### PR TITLE
Escape special characters

### DIFF
--- a/lib/envme.rb
+++ b/lib/envme.rb
@@ -29,7 +29,7 @@ module Envme
 
     def file_builder(var_collection, filename)
       var_collection.collect{ |var|
-        "echo #{var} >> #{filename}"
+        "echo '#{var}' >> #{filename}"
       }.sort.join("\n")
     end
   end


### PR DESCRIPTION
Just need this to quote the vars so that special characters in the strings do not blow up the unix command line